### PR TITLE
Config is deprecated, use RbConfig

### DIFF
--- a/ext/mysql_api/extconf.rb
+++ b/ext/mysql_api/extconf.rb
@@ -59,9 +59,9 @@ File.open("conftest.c", "w") do |f|
   f.puts src
 end
 if defined? cpp_command then
-  cpp = Config.expand(cpp_command(''))
+  cpp = RbConfig.expand(cpp_command(''))
 else
-  cpp = Config.expand sprintf(CPP, $CPPFLAGS, $CFLAGS, '')
+  cpp = RbConfig.expand sprintf(CPP, $CPPFLAGS, $CFLAGS, '')
 end
 if RUBY_PLATFORM =~ /mswin/ && !/-E/.match(cpp)
   cpp << " -E"


### PR DESCRIPTION
The mysql gem won't build on Ruby 2.0.0 because the `Config` constant has been removed, so this switches it to `RbConfig`
