### PR TITLE
Use ULL2NUM for affected_rows

### DIFF
--- a/ext/mysql_api/mysql.c
+++ b/ext/mysql_api/mysql.c
@@ -445,7 +445,7 @@ static VALUE initialize(int argc, VALUE* argv, VALUE obj)
 /*	affected_rows()	*/
 static VALUE affected_rows(VALUE obj)
 {
-    return INT2NUM(mysql_affected_rows(GetHandler(obj)));
+    return ULL2NUM(mysql_affected_rows(GetHandler(obj)));
 }
 
 #if MYSQL_VERSION_ID >= 32303
@@ -1268,7 +1268,7 @@ static VALUE stmt_affected_rows(VALUE obj)
     my_ulonglong n;
     check_stmt_closed(obj);
     n = mysql_stmt_affected_rows(s->stmt);
-    return INT2NUM(n);
+    return ULL2NUM(n);
 }
 
 #if 0


### PR DESCRIPTION
This is a partial fix for #11.

I was able to bypass disk and memory requirements by using the BLACKHOLE engine, but the tests below take 22 minutes _each_ on my [older] desktop. Without this commit, these tests fail with `<4294967296> expected but was <0>`.

``` diff
diff --git a/test/test_mysql.rb b/test/test_mysql.rb
index f9013cd..543db6c 100644
--- a/test/test_mysql.rb
+++ b/test/test_mysql.rb
@@ -131,6 +131,16 @@ class TC_Mysql2 < Test::Unit::TestCase
     assert_equal(1, @m.affected_rows)
   end

+  def test_affected_rows_bigint()
+    @m.query("CREATE OR REPLACE VIEW null_16  AS SELECT NULL#{' UNION ALL SELECT NULL' * 15}")
+    @m.query("CREATE OR REPLACE VIEW null_256 AS SELECT NULL FROM null_16  a, null_16  b")
+    @m.query("CREATE OR REPLACE VIEW null_64k AS SELECT NULL FROM null_256 a, null_256 b")
+    @m.query("CREATE OR REPLACE VIEW null_4g  AS SELECT NULL FROM null_64k a, null_64k b")
+
+    @m.query("CREATE TEMPORARY TABLE t ENGINE BLACKHOLE AS SELECT * FROM null_4g")
+    assert_equal(4_294_967_296, @m.affected_rows)
+  end
+
   def test_autocommit()
     if @m.methods.include? "autocommit" then
       assert_equal(@m, @m.autocommit(true))
@@ -506,6 +516,17 @@ class TC_MysqlStmt2 < Test::Unit::TestCase
     end
   end

+  def test_affected_rows_bigint()
+    @m.query("CREATE OR REPLACE VIEW null_16  AS SELECT NULL#{' UNION ALL SELECT NULL' * 15}")
+    @m.query("CREATE OR REPLACE VIEW null_256 AS SELECT NULL FROM null_16  a, null_16  b")
+    @m.query("CREATE OR REPLACE VIEW null_64k AS SELECT NULL FROM null_256 a, null_256 b")
+    @m.query("CREATE OR REPLACE VIEW null_4g  AS SELECT NULL FROM null_64k a, null_64k b")
+
+    @s.prepare("CREATE TEMPORARY TABLE t ENGINE BLACKHOLE AS SELECT * FROM null_4g")
+    @s.execute
+    assert_equal(4_294_967_296, @s.affected_rows)
+  end
+
 =begin
   def test_attr_get()
     assert_equal(false, @s.attr_get(Mysql::Stmt::ATTR_UPDATE_MAX_LENGTH))
```
