### PR TITLE
Using Markdown for README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-= MySQL/Ruby Interface
+# MySQL/Ruby Interface
 
 * http://github.com/luislavena/mysql-gem
 
-== DESCRIPTION
+## DESCRIPTION
 
 This is the MySQL API module for Ruby. It provides the same functions for Ruby
 programs that the MySQL C API provides for C programs.
@@ -13,7 +13,7 @@ unmodified tmtm's mysql-ruby extension into a proper gem.
 Please note that tmtm (Tomita Mashahiro) has deprecated development of this
 extension and only update it for bug fixes.
 
-=== Warning about incompatible MySQL versions under Windows
+### Warning about incompatible MySQL versions under Windows
 
 Mixing MySQL versions will generate segmentation faults.
 


### PR DESCRIPTION
GitHub automatically creates HTML links for README.md's and other Markdown files.
