### PR TITLE
setting 'errno' to nil to prevent warnings fetching it

### DIFF
--- a/ext/mysql_api/mysql.c
+++ b/ext/mysql_api/mysql.c
@@ -731,10 +731,11 @@ static VALUE res_free(VALUE);
 static VALUE query(VALUE obj, VALUE sql)
 {
     int loop = 0;
+    VALUE e;
     MYSQL* m = GetHandler(obj);
     Check_Type(sql, T_STRING);
     if (GetMysqlStruct(obj)->connection == Qfalse) {
-        VALUE e = rb_exc_new2(eMysql, "query: test not connected");
+        e = rb_exc_new2(eMysql, "query: not connected");
         rb_iv_set(e, "errno", Qnil);
         rb_exc_raise(e);
     }


### PR DESCRIPTION
Dear Luis,

I know we don't maintain this gem anymore except for bug fixes, but this particular exception has a test case on ActiveRecord and it triggers a warning when trying to access `errno`. It would be great if this could be merged and a new gem released just so we wouldn't have to see the warning in the middle of the test run.

Unfortunately since `errno` is an instance var without "@" there's no other way i can think of to avoid the warning besides updating the gem. 

I know it's kind of frivolous, but do you think we could have the gem updated? It'd also close #25. If it's not possible I'll understand.

Thanks either way!
