### PR TITLE
Remove rubyforge

### DIFF
--- a/extra/README.html
+++ b/extra/README.html
@@ -19,7 +19,6 @@
 
     <h2>Download</h2>
     <ul>
-      <li><a href="http://rubyforge.org/frs/?group_id=4550">RubyForge</a>
       <li><a href="http://tmtm.org/downloads/mysql/ruby/">tmtm.org</a>
     </ul>
 

--- a/extra/README_ja.html
+++ b/extra/README_ja.html
@@ -18,7 +18,6 @@
 
     <h2>ダウンロード</h2>
     <ul>
-      <li><a href="http://rubyforge.org/frs/?group_id=4550">RubyForge</a>
       <li><a href="http://tmtm.org/downloads/mysql/ruby/">tmtm.org</a>
     </ul>
 

--- a/tasks/gem.rake
+++ b/tasks/gem.rake
@@ -2,7 +2,6 @@ require 'rubygems/package_task'
 require 'hoe'
 
 HOE = Hoe.spec 'mysql' do
-  self.rubyforge_name = 'mysql-win'
   self.author         = ['TOMITA Masahiro']
   self.email          = %w[tommy@tmtm.org]
   self.need_tar       = false


### PR DESCRIPTION
Rubyforge was removed from the hoe gem and thus throwing erros.

Inspired by:
https://github.com/ruby-ldap/ruby-net-ldap/commit/cc32757fa5b2c9183b19200f002be62a88144afa